### PR TITLE
No usar data-target cuando activas modal desde un enlace

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
             <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" href="#noticias">Noticias</a>
           </li>
           <li class="nav-item mx-0 mx-lg-1">
-            <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" data-toggle="modal" data-target="#portfolio-modal-login" href="#portfolio-modal-login">Servicios</a>
+            <a class="nav-link py-3 px-0 px-lg-3 rounded" data-toggle="modal" href="#portfolio-modal-login">Servicios</a>
           </li>
           <li class="nav-item mx-0 mx-lg-1">
             <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" href="#about">Acerca de nosotros</a>
@@ -173,10 +173,10 @@
     </div>
   </div>
 
-  <div class="portfolio-modal mfp-hide" id="portfolio-modal-login">
+  <div class="portfolio-modal modal"  id="portfolio-modal-login">
     <div class="portfolio-modal-dialog bg-white">
       <a class="close-button d-none d-md-block portfolio-modal-dismiss" href="#">
-        <i class="fa fa-3x fa-times"></i>
+        <i class="fa fa-3x fa-times" data-dismiss="modal"></i>
       </a>
       <div class="container text-center">
         <!--Titulo del modal-->


### PR DESCRIPTION
Modifiqué tu enlace, quitando el data-target. De igual manera quité la clase js-scroll-trigger ya que tenía otra acción al hacer click. Agregué la clase 'modal' al portfolio-modal para que se comportara como tal 